### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v0*' # Executa quando um tag começando com "v" é feita (ex: v1.3.0)
 
+permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/StephHoel/gastometro/security/code-scanning/1](https://github.com/StephHoel/gastometro/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/android-release.yml` so the workflow does not rely on inherited defaults.

Best fix (without changing intended functionality): define workflow-level permissions with least privilege needed by existing steps:
- `contents: write` (required for `softprops/action-gh-release` to create/update releases and upload assets)
- `actions: read` (safe minimal read for actions metadata; optional but commonly acceptable)
- `packages: read` is not required by shown steps, so omit unless needed.
- Keep scope minimal; do not grant broad write permissions beyond what release upload needs.

Apply this near the top-level (after `on:` block and before `jobs:`) so it covers all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
