### PR TITLE
chore: remove unused dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,6 @@
             "devDependencies": {
                 "@babel/core": "^7.25.2",
                 "@types/react": "~19.2.14",
-                "@types/react-native-vector-icons": "^6.4.18",
-                "expo-atlas": "^0.4.0",
                 "typescript": "~6.0.3"
             }
         },
@@ -2931,17 +2929,6 @@
                 "@types/react": "*"
             }
         },
-        "node_modules/@types/react-native-vector-icons": {
-            "version": "6.4.18",
-            "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.18.tgz",
-            "integrity": "sha512-YGlNWb+k5laTBHd7+uZowB9DpIK3SXUneZqAiKQaj1jnJCZM0x71GDim5JCTMi4IFkhc9m8H/Gm28T5BjyivUw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/react": "*",
-                "@types/react-native": "^0.70"
-            }
-        },
         "node_modules/@types/react-test-renderer": {
             "version": "19.1.0",
             "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
@@ -4349,33 +4336,6 @@
                 "expo": "*",
                 "react": "*",
                 "react-native": "*"
-            }
-        },
-        "node_modules/expo-atlas": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/expo-atlas/-/expo-atlas-0.4.3.tgz",
-            "integrity": "sha512-nN2bouxFvMsqZqLl0ka+eI9Ofida0PcuoE4v+7fHlgyp95X2cCL8Acf0nRKXmmIBEYazdw0d7BAOZfC0b41oxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@expo/server": "^0.5.0",
-                "arg": "^5.0.2",
-                "chalk": "^4.1.2",
-                "compression": "^1.7.4",
-                "connect": "^3.7.0",
-                "express": "^4.19.2",
-                "freeport-async": "^2.0.0",
-                "getenv": "^2.0.0",
-                "morgan": "^1.10.0",
-                "open": "^8.4.2",
-                "serve-static": "^1.15.0",
-                "stream-json": "^1.8.0"
-            },
-            "bin": {
-                "expo-atlas": "build/src/cli/bin.js"
-            },
-            "peerDependencies": {
-                "expo": "*"
             }
         },
         "node_modules/expo-clipboard": {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
     "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/react": "~19.2.14",
-        "@types/react-native-vector-icons": "^6.4.18",
-        "expo-atlas": "^0.4.0",
         "typescript": "~6.0.3"
     },
     "private": true,


### PR DESCRIPTION
### Motivation
- Remover dependências de desenvolvimento não utilizadas do manifesto e manter o lockfile consistente para reduzir manutenção e tempo de instalação.

### Description
- Removi `@types/react-native-vector-icons` e `expo-atlas` de `devDependencies` em `package.json` e limpei as entradas correspondentes no bloco raiz de `devDependencies` em `package-lock.json`, mantendo `@babel/core`, `@types/react` e `typescript` intactos; os arquivos atualizados foram commitados.

### Testing
- Executei `npx -y depcheck` (falhou por restrição de acesso ao registry), depois verifiquei ausência de uso com uma varredura estática via `rg`/script Python que reportou nenhuma correspondência para os pacotes removidos, e confirmei as alterações com `node` checks e `git commit` que atualizaram `package.json` e `package-lock.json` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1306ce302083259ea9d6b439f4f231)