### PR TITLE
ci: update github actions to support node.js 24

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build-apk_gh-release.yml
+++ b/.github/workflows/build-apk_gh-release.yml
@@ -43,7 +43,7 @@ jobs:
           ./scripts/build-local.sh
 
       - name: Upload APK as Artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: gastometro
           path: _apks/*.apk


### PR DESCRIPTION
## Descrição

Atualiza as versões das GitHub Actions para suportar Node.js 24 e resolver os avisos de deprecação.

## Mudanças

- ✅ `ai-review.yml`: atualiza `actions/checkout` de v3 para v4
- ✅ `build-apk_gh-release.yml`: atualiza `actions/upload-artifact` para v4 (versão mais recente)

Essas versões já foram compiladas para Node.js 24 e resolvem os avisos de deprecação que apareciam na pipeline.

## Referência

Relacionado ao aviso de deprecação do GitHub Actions sobre Node.js 20 ser removido em 16 de junho de 2026.