### PR TITLE
ci: criar releases por versao e alpha para nao-main

### DIFF
--- a/.github/workflows/build-apk_gh-release.yml
+++ b/.github/workflows/build-apk_gh-release.yml
@@ -108,7 +108,7 @@ jobs:
             echo "Creating new prerelease for version '$VERSION' (tag '$TAG')..."
             gh release create "$TAG" "$APK_PATH" \
               --title "v${VERSION}-alpha" \
-              --target release \
+              --target $GITHUB_SHA \
               --generate-notes \
               --prerelease
           fi

--- a/.github/workflows/build-apk_gh-release.yml
+++ b/.github/workflows/build-apk_gh-release.yml
@@ -87,7 +87,8 @@ jobs:
         if: ${{ github.ref_name != 'main' }}
         run: |
           CURRENT_DATETIME=$(date +"%d-%m-%Y %H:%M:%S")
-          TAG="dev"
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}-alpha"
           APK_PATH=$(ls -1 _apks/*.apk 2>/dev/null | head -n1 || true)
 
           if [ -z "$APK_PATH" ]; then
@@ -95,13 +96,18 @@ jobs:
             exit 1
           fi
 
+          if [ -z "$VERSION" ]; then
+            echo "Could not read version from package.json"
+            exit 1
+          fi
+
           if gh release view "$TAG" > /dev/null 2>&1; then
-            echo "Release with tag '$TAG' exists. Uploading new APK..."
+            echo "Release with tag '$TAG' already exists. Uploading new APK for this alpha version..."
             gh release upload "$TAG" "$APK_PATH" --clobber
           else
-            echo "Creating new prerelease with tag '$TAG'..."
+            echo "Creating new prerelease for version '$VERSION' (tag '$TAG')..."
             gh release create "$TAG" "$APK_PATH" \
-              --title "Builded at $CURRENT_DATETIME" \
+              --title "v${VERSION}-alpha" \
               --target release \
               --generate-notes \
               --prerelease

--- a/.github/workflows/build-apk_gh-release.yml
+++ b/.github/workflows/build-apk_gh-release.yml
@@ -77,7 +77,7 @@ jobs:
             echo "Creating new release for version '$VERSION' (tag '$TAG')..."
             gh release create "$TAG" "$APK_PATH" \
               --title "v$VERSION" \
-              --target main \
+              --target $GITHUB_SHA \
               --generate-notes
           fi
 

--- a/.github/workflows/build-apk_gh-release.yml
+++ b/.github/workflows/build-apk_gh-release.yml
@@ -56,7 +56,8 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         run: |
           CURRENT_DATETIME=$(date +"%d-%m-%Y %H:%M:%S")
-          TAG="main"
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
           APK_PATH=$(ls -1 _apks/*.apk 2>/dev/null | head -n1 || true)
 
           if [ -z "$APK_PATH" ]; then
@@ -64,13 +65,18 @@ jobs:
             exit 1
           fi
 
+          if [ -z "$VERSION" ]; then
+            echo "Could not read version from package.json"
+            exit 1
+          fi
+
           if gh release view "$TAG" > /dev/null 2>&1; then
-            echo "Release with tag '$TAG' exists. Uploading new APK..."
+            echo "Release with tag '$TAG' already exists. Uploading new APK for this version..."
             gh release upload "$TAG" "$APK_PATH" --clobber
           else
-            echo "Creating new release with tag '$TAG'..."
+            echo "Creating new release for version '$VERSION' (tag '$TAG')..."
             gh release create "$TAG" "$APK_PATH" \
-              --title "Builded at $CURRENT_DATETIME" \
+              --title "v$VERSION" \
               --target main \
               --generate-notes
           fi


### PR DESCRIPTION
## Resumo
- usa a versao do `package.json` para tag/release no fluxo da `main` (`vX.Y.Z`)
- cria nova release automaticamente quando a versao muda
- para branches nao-main, aplica o mesmo padrao com sufixo `-alpha` (`vX.Y.Z-alpha`)
- mantém upload com `--clobber` quando a release da mesma versao ja existe

## Arquivo alterado
- `.github/workflows/build-apk_gh-release.yml`

## Commits
- `68b413b` ci: criar release por versao do package no main
- `9ff8edf` ci: versionar prerelease alpha para branches nao-main