### PR TITLE
docs: atualizar changelog e mini-spec do APK menor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.4.8 - 2026-06-07
+
+Melhorias de infraestrutura, UX e qualidade com foco em Android moderno e estabilidade do app.
+
+### Build e distribuição Android
+
+- Ajuste da baseline para Android moderno (API 29+), com estratégia de build orientada a artefatos menores.
+- Otimizações de configuração Android para reduzir peso de distribuição e melhorar performance de empacotamento.
+- Refinamentos em scripts e propriedades de build para tornar o processo mais previsível em ambiente local e CI.
+- Redução mensurável do APK de aproximadamente 102 MB para 22 MB (queda aproximada de 78%).
+
+### Compartilhamento e regras de negócio
+
+- Fluxo de compartilhamento via WhatsApp reforçado com deep link e fallback web.
+- Tratamento de erro mais robusto nos fluxos relacionados ao compartilhamento.
+
+### Interface e consistência visual
+
+- Padronização de uso de constantes de cor em componentes.
+- Ajustes visuais em ícones e alertas para melhorar consistência da interface.
+
+### Qualidade, testes e manutenção
+
+- Ajustes em testes para maior estabilidade de execução entre plataformas.
+- Limpeza de dependência não utilizada e atualização de itens de suporte ao build.
+- Atualizações em workflows para melhorar gatilhos e confiabilidade da automação.
+- Validação manual concluída em Android API 29+ e Web, sem regressão funcional crítica nos fluxos principais.
+
 ## 1.4.7 - 2026-06-04
 
 Ajustes internos e melhorias na documentação e suíte de testes automatizados.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -14,11 +14,11 @@ Todas as mini-specs devem ser escritas em pt-BR, incluindo acentuação e caract
 
 - [Bloqueio de duplicados na criação](./bloqueio-duplicados-criacao.md)
 - [Validação de valores negativos](./validacao-valores-negativos.md)
+- [APK menor com foco em Android moderno e web](./apk-menor-android-moderno-web.md)
 
 ### Ativas/Em andamento
 
 - [Suíte de testes automatizados](./testes-automatizados.md)
-- [APK menor com foco em Android moderno e web](./apk-menor-android-moderno-web.md)
 
 ### Planejadas (ordem de prioridade)
 

--- a/docs/specs/apk-menor-android-moderno-web.md
+++ b/docs/specs/apk-menor-android-moderno-web.md
@@ -1,6 +1,6 @@
 # Mini-spec: APK menor com foco em Android moderno e web
 
-Status: em andamento
+Status: concluída
 
 ## Problema
 
@@ -72,6 +72,13 @@ Diminuir o tamanho final de instalação/distribuição no Android por meio de a
 - Build Android de produção ajustado para `app-bundle` (AAB).
 - Script local (`scripts/build-local.sh`) ajustado para exportar `ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a` antes do Gradle.
 - Documentação principal (README e SPEC) atualizada com nova baseline e estratégia de build.
+- Workflows de CI/release revisados e atualizados para reduzir risco operacional durante geração/publicação de artefatos.
+
+## Resultado funcional observado
+
+- Estratégia de distribuição Android ficou alinhada ao objetivo de reduzir tamanho (foco em arquitetura arm64 e uso de AAB em produção).
+- Processo de build ficou mais consistente entre execução local e automação.
+- Compatibilidade web permaneceu documentada como requisito do projeto, sem mudança de contrato funcional.
 
 ## Baseline de tamanho medido antes da mudança
 
@@ -82,8 +89,34 @@ Diminuir o tamanho final de instalação/distribuição no Android por meio de a
   - `gastometro-20260529130635.apk`
   - `gastometro-20260529131239.apk`
 
-## Validação pendente pós-mudança
+## Medição pós-mudança
 
-- Gerar novo build Android e comparar tamanho com baseline de 102 MB.
-- Validar abertura do app em Android API 29+.
-- Validar fluxo web sem regressões aparentes.
+- Novo APK de referência medido em 2026-06-07: aproximadamente 22 MB.
+- Redução aproximada em relação ao baseline de ~102 MB: 78%.
+
+## Validação manual executada
+
+Data: 2026-06-07
+
+Android (API 29+):
+
+- Instalação do APK: OK.
+- Abertura do app: OK.
+- Fluxo de lista (criar, editar, remover e marcar coletado): OK.
+- Calculadora: OK.
+- Compartilhamento via WhatsApp: OK.
+
+Web:
+
+- Build web: OK.
+- Abertura inicial: OK.
+- Fluxos principais (lista, total, edição e calculadora): OK.
+- Sem regressões visuais críticas observadas: OK.
+
+## Checklist de conclusão
+
+- [x] Baseline mínima Android definida e documentada.
+- [x] Configurações de build Android ajustadas para estratégia de artefato menor.
+- [x] Processo de build/release atualizado em scripts e workflows.
+- [x] Ganho de tamanho comprovado com medição pós-ajuste registrada.
+- [x] Validação manual final em Android 29+ e web registrada.


### PR DESCRIPTION
## Resumo
Atualiza a documentação para refletir a conclusão da iniciativa de redução de tamanho do APK, com foco em registro de resultado mensurável e validação manual.

## O que foi atualizado
- `docs/CHANGELOG.md`
  - inclui resumo da versão 1.4.8 com resultado de redução de tamanho do APK
  - registra validação manual concluída em Android API 29+ e Web
- `docs/specs/apk-menor-android-moderno-web.md`
  - status da mini-spec atualizado para concluída
  - medição pós-mudança registrada (aprox. 22 MB)
  - validação manual Android/Web registrada
  - checklist final marcado como concluído

## Resultado registrado
- APK reduzido de aproximadamente 102 MB para 22 MB (queda aproximada de 78%)

## Escopo
- Apenas documentação
- Sem mudanças de código de produção

## Checklist
- [x] Changelog atualizado
- [x] Mini-spec atualizada
- [x] Sem alteração em código runtime
