### PR TITLE
docs: renumerar mini-specs e alinhar instruções ao estado atual

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,11 +12,13 @@ Resumo rápido:
 - Domínio principal: lista de compras, total em BRL, compartilhamento/importação via WhatsApp e calculadora de preço por unidade.
 - Use imports internos com alias `@/`.
 - Evite `any`.
-- Não assuma Prisma, PostgreSQL, Jest ou Zod: eles não fazem parte da stack atual.
+- Não assuma Prisma, PostgreSQL ou Zod: eles não fazem parte da stack atual.
+- A suíte de testes já existe com Jest (`npm run test`) e gate de cobertura global de 80%.
 - Preserve regras pt-BR de moeda, números com vírgula/ponto e textos do usuário.
 - Preserve comportamento existente, formato de dados persistidos e formato de WhatsApp, salvo confirmação explícita do usuário.
 - Tema escuro e identidade fixa do app.
 - Para funcionalidades maiores, preencha uma mini-spec no formato indicado em `docs/SPEC.md`.
+- Para mini-specs novas, usar nome com prefixo numérico sequencial em `docs/specs/planned/` (ex.: `12-nome-da-feature.md`) e incluir campo `Número: NN` no documento.
 
 Responsabilidades:
 

--- a/.github/prompts/generate-tests.prompt.md
+++ b/.github/prompts/generate-tests.prompt.md
@@ -1,4 +1,4 @@
 Analise os arquivos alterados.
-Crie testes automatizados seguindo a estratégia definida no `docs/SPEC.md` (sem assumir Jest/RTL se a suíte ainda não existir).
-Se a suíte de testes não estiver configurada, proponha a configuração em `docs/specs/` e documente como executar.
+Crie testes automatizados seguindo a estratégia definida no `docs/SPEC.md` e a suíte atual com Jest (`npm run test`).
+Mantenha ou amplie cobertura proporcional ao escopo e preserve o gate global de 80%.
 Não altere a lógica existente.

--- a/.github/prompts/review-pr.prompt.md
+++ b/.github/prompts/review-pr.prompt.md
@@ -7,5 +7,8 @@ Verifique:
 - Segurança
 - Código duplicado
 - Testes faltantes
+- Aderência ao `docs/SPEC.md`
+- Convenção de mini-specs numeradas (`NN-nome.md` + campo `Número: NN`)
+- Impacto no gate global de cobertura de testes (80%)
 
 Crie um relatório técnico.

--- a/.github/prompts/tech-lead.prompt.md
+++ b/.github/prompts/tech-lead.prompt.md
@@ -12,4 +12,10 @@ Execute:
 6. Refatore duplicações.
 7. Gere relatório final.
 
+Valide também:
+
+- convenção de mini-specs numeradas (`NN-nome.md` + campo `Número: NN`);
+- aderência ao `docs/SPEC.md`;
+- manutenção do gate global de cobertura (80%) quando houver alterações em testes.
+
 Faça todas as alterações necessárias.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ Implementação da visualização de total de itens coletados na tela principal,
 
 ### Documentação
 
-- Atualiza mini-spec `docs/specs/total-itens-coletados.md` para `Status: implementado`.
+- Atualiza mini-spec `docs/specs/done/03-total-itens-coletados.md` para `Status: implementado`.
 - Atualiza README e SPEC para refletir que o total coletado não é mais item planejado.
 
 ## 1.4.8 - 2026-06-07

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -42,6 +42,7 @@ Público esperado:
 
 Todas as funcionalidades abaixo devem ser implementadas futuramente, mas ainda precisam de mini-spec antes da execução:
 
+- itens coletados no final da lista (com divisão clara entre coletados e não coletados);
 - notificações/lembretes;
 - múltiplas listas com títulos personalizados;
 - contas a pagar;
@@ -71,7 +72,7 @@ Use esta seção como verdade atual do repositório.
 - Plataforma futura: web compatível com GitHub Pages.
 - Baseline atual de compatibilidade Android: API 29+ (Android 10).
 
-Não assumir Prisma, PostgreSQL, Jest ou Zod sem antes adicionar essas dependências e justificar a mudança. O arquivo antigo do Copilot citava essas tecnologias, mas elas não aparecem na stack atual.
+Não assumir Prisma, PostgreSQL ou Zod sem antes adicionar essas dependências e justificar a mudança. O arquivo antigo do Copilot citava tecnologias que não aparecem na stack atual.
 
 ## 5. Estrutura de Pastas
 
@@ -308,10 +309,21 @@ Ao finalizar:
 
 ## 16. Template de Mini-Spec para Novas Features
 
-As mini-specs do projeto ficam em `docs/specs/` e são separadas por status. Novas mini-specs devem nascer em `docs/specs/planned/`, migrar para `docs/specs/active/` quando entrarem em execução e ir para `docs/specs/done/` quando virarem referência estável. Elas devem ser escritas em pt-BR, incluindo acentuação e caracteres especiais. Copie e preencha o modelo abaixo antes de implementar funcionalidades maiores que ainda não tenham documento próprio:
+As mini-specs do projeto ficam em `docs/specs/` e são separadas por status. Novas mini-specs devem nascer em `docs/specs/planned/`, migrar para `docs/specs/active/` quando entrarem em execução e ir para `docs/specs/done/` quando virarem referência estável. Elas devem ser escritas em pt-BR, incluindo acentuação e caracteres especiais.
+
+Convenção obrigatória de mini-spec:
+
+- nome de arquivo com prefixo numérico sequencial de criação: `NN-nome-da-feature.md`;
+- campo `Número: NN` logo após o título;
+- campo `Status:` mantido e atualizado conforme o estágio (`planejado`, `ativa`, `implementado`, `concluída`).
+
+Copie e preencha o modelo abaixo antes de implementar funcionalidades maiores que ainda não tenham documento próprio:
 
 ```md
-## Feature: <nome>
+# Mini-spec: <nome>
+
+Número: <NN>
+Status: planejado
 
 Problema:
 - <qual problema do usuário resolve?>

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -18,19 +18,20 @@ Todas as mini-specs devem ser escritas em pt-BR, incluindo acentuação e caract
 
 ### Implementadas
 
-- [Bloqueio de duplicados na criação](./done/bloqueio-duplicados-criacao.md)
-- [Validação de valores negativos](./done/validacao-valores-negativos.md)
-- [APK menor com foco em Android moderno e web](./done/apk-menor-android-moderno-web.md)
-- [Total de itens coletados](./done/total-itens-coletados.md)
+- [01 - Bloqueio de duplicados na criação](./done/01-bloqueio-duplicados-criacao.md)
+- [02 - Validação de valores negativos](./done/02-validacao-valores-negativos.md)
+- [03 - Total de itens coletados](./done/03-total-itens-coletados.md)
+- [04 - APK menor com foco em Android moderno e web](./done/04-apk-menor-android-moderno-web.md)
 
 ### Ativas/Em andamento
 
-- [Suíte de testes automatizados](./active/testes-automatizados.md)
+- [05 - Suíte de testes automatizados](./active/05-testes-automatizados.md)
 
 ### Planejadas (ordem de prioridade)
 
-1. [Gestão de itens duplicados](./planned/gestao-itens-duplicados.md)
-2. [Web compatível com GitHub Pages](./planned/web-github-pages.md)
-3. [Múltiplas listas](./planned/multiplas-listas.md)
-4. [Notificações e lembretes](./planned/notificacoes-lembretes.md)
-5. [Contas a pagar](./planned/contas-a-pagar.md)
+1. [07 - Itens coletados no final da lista](./planned/07-itens-coletados-no-final-da-lista.md)
+2. [06 - Gestão de itens duplicados](./planned/06-gestao-itens-duplicados.md)
+3. [08 - Web compatível com GitHub Pages](./planned/08-web-github-pages.md)
+4. [09 - Múltiplas listas](./planned/09-multiplas-listas.md)
+5. [10 - Notificações e lembretes](./planned/10-notificacoes-lembretes.md)
+6. [11 - Contas a pagar](./planned/11-contas-a-pagar.md)

--- a/docs/specs/active/05-testes-automatizados.md
+++ b/docs/specs/active/05-testes-automatizados.md
@@ -1,5 +1,6 @@
 # Mini-spec: Suíte de testes automatizados
 
+Número: 05
 Status: ativa (evolução contínua)
 
 ## Problema Inicial

--- a/docs/specs/done/01-bloqueio-duplicados-criacao.md
+++ b/docs/specs/done/01-bloqueio-duplicados-criacao.md
@@ -1,5 +1,6 @@
 # Mini-spec: Bloqueio de duplicados na criação manual
 
+Número: 01
 Status: implementado
 
 ## Problema

--- a/docs/specs/done/02-validacao-valores-negativos.md
+++ b/docs/specs/done/02-validacao-valores-negativos.md
@@ -1,5 +1,6 @@
 # Mini-spec: Validação de valores negativos
 
+Número: 02
 Status: implementado
 
 ## Problema

--- a/docs/specs/done/03-total-itens-coletados.md
+++ b/docs/specs/done/03-total-itens-coletados.md
@@ -1,5 +1,6 @@
 # Mini-spec: Total de itens coletados
 
+Número: 03
 Status: implementado
 
 ## Problema

--- a/docs/specs/done/04-apk-menor-android-moderno-web.md
+++ b/docs/specs/done/04-apk-menor-android-moderno-web.md
@@ -1,5 +1,6 @@
 # Mini-spec: APK menor com foco em Android moderno e web
 
+Número: 04
 Status: concluída
 
 ## Problema

--- a/docs/specs/planned/06-gestao-itens-duplicados.md
+++ b/docs/specs/planned/06-gestao-itens-duplicados.md
@@ -1,5 +1,6 @@
 # Mini-spec: Gestão de itens duplicados
 
+Número: 06
 Status: planejado
 
 ## Problema

--- a/docs/specs/planned/07-itens-coletados-no-final-da-lista.md
+++ b/docs/specs/planned/07-itens-coletados-no-final-da-lista.md
@@ -1,0 +1,66 @@
+# Mini-spec: Itens coletados no final da lista
+
+Número: 07
+Status: planejado
+
+## Problema
+
+Hoje os itens podem ficar misturados entre coletados e não coletados na lista principal, o que reduz a velocidade de leitura durante a compra.
+
+## Objetivo
+
+Exibir itens não coletados primeiro e mover itens coletados para o final da lista, com uma divisão visual clara entre os dois blocos.
+
+## Comportamento esperado
+
+- A lista deve renderizar primeiro os itens com `collected: false`.
+- A lista deve renderizar no final os itens com `collected: true`.
+- Deve existir um divisor visual claro entre os blocos de não coletados e coletados.
+- Ao marcar um item como coletado, ele deve migrar imediatamente para o bloco final.
+- Ao desmarcar um item coletado, ele deve voltar imediatamente para o bloco inicial.
+- Quando não houver itens coletados, o divisor não deve ser exibido.
+- Quando todos os itens estiverem coletados, a lista deve manter consistência visual sem bloco vazio no topo.
+
+## Decisões fechadas
+
+- A divisão é apenas visual e não altera o formato persistido de `ProductProps`.
+- O estado `collected` continua sendo a única fonte de verdade para posicionamento entre os blocos.
+- O comportamento deve preservar o fluxo de edição e remoção já existente para qualquer item.
+
+## Telas afetadas
+
+- Tela principal.
+- Componente de lista e seus itens.
+
+## Dados e persistência
+
+- Não deve criar novo campo no produto.
+- Não deve alterar a chave de persistência `gastometro`.
+- Não deve alterar o contrato de compartilhamento/importação via WhatsApp.
+
+## Regras de validação
+
+- O agrupamento por coletado deve ser aplicado apenas na exibição da lista.
+- Dentro de cada bloco, manter a regra de ordenação alfabética vigente, salvo decisão explícita em outra mini-spec.
+- O divisor deve ter contraste compatível com o tema escuro atual.
+
+## Critérios de aceite
+
+- Com itens mistos, a lista mostra primeiro não coletados e depois coletados.
+- O divisor entre blocos aparece apenas quando ambos os grupos existem.
+- Marcar item move para o bloco final sem exigir recarregamento da tela.
+- Desmarcar item move para o bloco inicial sem exigir recarregamento da tela.
+- Editar e remover continuam funcionando nos dois blocos.
+- Total geral e total coletado permanecem corretos após as movimentações visuais.
+
+## Fora de escopo
+
+- Criar seção recolhível/expansível para coletados.
+- Criar ordenação manual por arrastar e soltar.
+- Alterar formato de exportação/importação da lista.
+
+## Observações para IA
+
+- Implementar agrupamento em função pura testável antes da renderização.
+- Cobrir com testes de componente para validar ordem visual e presença/ausência do divisor.
+- Cobrir com testes de store/helper caso a regra de ordenação seja centralizada fora da UI.

--- a/docs/specs/planned/08-web-github-pages.md
+++ b/docs/specs/planned/08-web-github-pages.md
@@ -1,5 +1,6 @@
 # Mini-spec: Web compatível com GitHub Pages
 
+Número: 08
 Status: planejado
 
 ## Problema

--- a/docs/specs/planned/09-multiplas-listas.md
+++ b/docs/specs/planned/09-multiplas-listas.md
@@ -1,5 +1,6 @@
 # Mini-spec: Múltiplas listas
 
+Número: 09
 Status: planejado
 
 ## Problema

--- a/docs/specs/planned/10-notificacoes-lembretes.md
+++ b/docs/specs/planned/10-notificacoes-lembretes.md
@@ -1,5 +1,6 @@
 # Mini-spec: Notificações e lembretes
 
+Número: 10
 Status: planejado
 
 ## Problema

--- a/docs/specs/planned/11-contas-a-pagar.md
+++ b/docs/specs/planned/11-contas-a-pagar.md
@@ -1,5 +1,6 @@
 # Mini-spec: Contas a pagar
 
+Número: 11
 Status: planejado
 
 ## Problema


### PR DESCRIPTION
## Resumo
- renumera mini-specs com prefixo sequencial (01- a 11-)
- adiciona campo Número: NN em todas as mini-specs
- adiciona mini-spec nova para itens coletados no final da lista (07)
- atualiza referências e índice em docs/specs/README.md
- atualiza instruções do Copilot e prompts para refletir suíte de testes existente e convenção de mini-spec numerada
- atualiza docs/SPEC.md com convenção e template atual

## Escopo
Mudanças apenas em documentação e instruções (docs/ e .github/).

## Checklist
- [x] sem mudanças em src/
- [x] sem mudanças em tests/
- [x] sem mudanças em scripts/