### PR TITLE
chore: release v1.4.11

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Gastômetro",
     "slug": "gastometro",
-    "version": "1.4.10",
+    "version": "1.4.11",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "gastometro",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.11 - 2026-06-13
+
+Refatoração da spec 12: redução de código duplicado, remoção de código não utilizado e ampliação de cobertura de testes
+
 ## 1.4.10 - 2026-06-12
 
 Exibe itens coletados no final da lista, separados dos não coletados por cabeçalhos de seção com contador.
@@ -116,3 +120,4 @@ Correção da v1.4.1
 ## 1.4.0 - 2025-05-01
 
 Criação de calculadora de preços
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gastometro",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gastometro",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~56.0.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gastometro",
   "main": "expo-router/entry",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "scripts": {
     "new-version": "sh ./scripts/add-new-version.sh",
     "verify:version-bump": "sh ./scripts/verify-version-bump.sh",


### PR DESCRIPTION
## Resumo
Cria a versão **1.4.11** via fluxo oficial (`npm run new-version`).

## Alterações
- `package.json` → `version: 1.4.11`
- `app.json` → `expo.version: 1.4.11`
- `package-lock.json` atualizado (`npm i`)
- `docs/CHANGELOG.md` atualizado com entrada da release em `2026-06-13`

## Observações
- A atualização de `android/app/build.gradle` não foi incluída no commit porque o caminho `android/` está ignorado no repositório atual.

## Checklist
- [x] Version bump aplicado
- [x] Changelog atualizado
- [x] Branch publicada
- [x] PR aberto para `main`