### PR TITLE
docs: sincroniza status web, limitações e mini-specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Aplicativo mobile para organizar listas de compras de supermercado de forma simp
 - AsyncStorage para persistência local.
 - Node 24 conforme `.nvmrc`.
 
-O foco atual da plataforma é Android. A versão web compatível com GitHub Pages está em implementação ativa.
+O foco atual da plataforma é Android. A versão web compatível com GitHub Pages já está disponível com limitações documentadas.
 
 Compatibilidade atual de plataforma:
 
@@ -49,9 +49,9 @@ As funcionalidades planejadas são documentadas em mini-specs dentro de [`docs/s
 - Múltiplas listas.
 - Contas a pagar.
 
-Funcionalidade em andamento:
+Funcionalidades concluídas recentemente:
 
-- Versão web compatível com GitHub Pages (mini-spec 08 em `docs/specs/active/`).
+- Compatibilidade web com GitHub Pages (mini-spec 08 em `docs/specs/done/`).
 
 Antes de implementar uma feature maior, consulte o [`docs/SPEC.md`](docs/SPEC.md) e a mini-spec correspondente.
 
@@ -126,6 +126,15 @@ npm run web:serve
 - O deploy para GitHub Pages é executado automaticamente pelo workflow `.github/workflows/deploy-web.yml` em pushes para `main`.
 - Antes do primeiro deploy, habilite GitHub Pages em `Settings > Pages` com `Source: GitHub Actions` (senão o `actions/deploy-pages` retorna erro 404).
 - A aplicação web está disponível em: **[https://stephhoel.github.io/gastometro/](https://stephhoel.github.io/gastometro/)**
+
+### Limitações web conhecidas
+
+- Compartilhamento via WhatsApp na web usa `wa.me`/WhatsApp Web, sem deep link nativo equivalente ao Android.
+- Clipboard na web depende de `navigator.clipboard`, permissões do navegador e contexto compatível (`https` ou `localhost`).
+- Os dados da web ficam no storage local do navegador e podem ser perdidos ao limpar dados do site.
+- Não existe sincronização entre dados da web e do Android.
+- A versão web não possui PWA/service worker neste momento; o primeiro carregamento depende de internet.
+- O fallback de roteamento SPA no GitHub Pages depende de `404.html` + `sessionStorage`; com storage desabilitado, rotas profundas podem não ser restauradas.
 
 ## Qualidade e testes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -69,7 +69,7 @@ Use esta seção como verdade atual do repositório.
 - Biome configurado parcialmente em `biome.json`.
 - Dependabot semanal para dependências npm.
 - Foco de plataforma: Android.
-- Plataforma em andamento: web compatível com GitHub Pages.
+- Plataforma suportada: Android (principal) e web estática compatível com GitHub Pages.
 - Baseline atual de compatibilidade Android: API 29+ (Android 10).
 
 Não assumir Prisma, PostgreSQL ou Zod sem antes adicionar essas dependências e justificar a mudança. O arquivo antigo do Copilot citava tecnologias que não aparecem na stack atual.
@@ -377,6 +377,6 @@ Fora de escopo:
 - Todas as funcionalidades planejadas devem ser implementadas futuramente.
 - Tema escuro deve ser mantido como identidade fixa.
 - Versionamento segue patch para fix/stack, minor para feature e major para mudança potencialmente quebrável.
-- Foco continua Android, com versão web em andamento compatível com GitHub Pages.
+- Foco continua Android, com suporte web estático disponível via GitHub Pages e limitações documentadas.
 - Baseline de Android suportado definida em API 29+, com foco em artefatos menores para Android moderno.
 - Todos os comportamentos devem ser preservados, exceto quando a feature aprovada os alterar com confirmação do usuário.

--- a/docs/WEB_DEPLOY.md
+++ b/docs/WEB_DEPLOY.md
@@ -166,6 +166,10 @@ Os dados são persistidos localmente usando `localStorage` do navegador através
 2. **Geolocalização:** Não implementado em web.
 3. **Sincronização:** Web e Android mantêm dados separados.
 4. **Offline-first:** A versão web requer internet para atualizar componentes da Expo, mas pode funcionar offline após o carregamento inicial.
+5. **WhatsApp na web:** O compartilhamento abre `wa.me`/WhatsApp Web; não há deep link nativo equivalente ao Android.
+6. **Clipboard e segurança:** `navigator.clipboard` exige ambiente seguro (`https`/`localhost`) e permissões do navegador.
+7. **Persistência local web:** Limpeza de dados do navegador pode remover o estado persistido da aplicação.
+8. **Fallback SPA:** O restore de rota profunda depende de `sessionStorage`; com storage desabilitado, o retorno de rota pode falhar.
 
 ## Troubleshooting
 

--- a/docs/WEB_DEPLOY.md
+++ b/docs/WEB_DEPLOY.md
@@ -169,7 +169,7 @@ Os dados são persistidos localmente usando `localStorage` do navegador através
 5. **WhatsApp na web:** O compartilhamento abre `wa.me`/WhatsApp Web; não há deep link nativo equivalente ao Android.
 6. **Clipboard e segurança:** `navigator.clipboard` exige ambiente seguro (`https`/`localhost`) e permissões do navegador.
 7. **Persistência local web:** Limpeza de dados do navegador pode remover o estado persistido da aplicação.
-8. **Fallback SPA:** O restore de rota profunda depende de `sessionStorage`; com storage desabilitado, o retorno de rota pode falhar.
+8. **Fallback SPA:** A restauração de rota profunda depende de `sessionStorage`; com storage desabilitado, o retorno de rota pode falhar.
 
 ## Troubleshooting
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -24,18 +24,18 @@ Todas as mini-specs devem ser escritas em pt-BR, incluindo acentuação e caract
 - [04 - APK menor com foco em Android moderno e web](./done/04-apk-menor-android-moderno-web.md)
 - [06 - União de itens duplicados](./done/06-uniao-itens-duplicados.md)
 - [07 - Itens coletados no final da lista](./done/07-itens-coletados-no-final-da-lista.md)
+- [08 - Web compatível com GitHub Pages](./done/08-web-github-pages.md)
 - [12 - Refactor — dead code e duplicação de código](./done/12-refactor-dead-code-e-duplicacao.md)
+- [15 - Limitações web explicitamente documentadas](./done/15-limitacoes-web-explicitas.md)
 
 ### Ativas/Em andamento
 
 - [05 - Suíte de testes automatizados](./active/05-testes-automatizados.md)
-- [08 - Web compatível com GitHub Pages](./active/08-web-github-pages.md)
 
 ### Planejadas (ordem de prioridade)
 
 1. [09 - Múltiplas listas](./planned/09-multiplas-listas.md)
 2. [10 - Notificações e lembretes](./planned/10-notificacoes-lembretes.md)
 3. [11 - Contas a pagar](./planned/11-contas-a-pagar.md)
-4. [14 - Testes E2E para roteamento web SPA](./planned/14-testes-e2e-roteamento-web-spa.md)
-5. [15 - Limitações web explicitamente documentadas](./planned/15-limitacoes-web-explicitas.md)
-6. [13 - Service Worker para funcionamento offline em web](./planned/13-service-worker-offline-web.md)
+4. [13 - Service Worker para funcionamento offline em web](./planned/13-service-worker-offline-web.md)
+5. [14 - Testes E2E para roteamento web SPA](./planned/14-testes-e2e-roteamento-web-spa.md)

--- a/docs/specs/done/08-web-github-pages.md
+++ b/docs/specs/done/08-web-github-pages.md
@@ -1,7 +1,7 @@
 # Mini-spec: Web compatível com GitHub Pages
 
 Número: 08
-Status: em desenvolvimento
+Status: implementado
 
 ## Problema
 
@@ -59,3 +59,9 @@ Permitir publicar uma build web estática do app no GitHub Pages sem quebrar o c
 
 - Estratégia definida: usar build estática com `expo export --platform web` no Expo 56.
 - Manter template HTML padrão do Expo para compatibilidade entre `npm run web` e build estática.
+
+## Registro de implementação
+
+- 2026-06-13: build web estática e deploy no GitHub Pages habilitados.
+- 2026-06-13: fallback de roteamento SPA implementado com `public/404.html` e `scripts/inject-spa-routing.js`.
+- 2026-06-13: documentação principal atualizada em `README.md`, `docs/WEB_DEPLOY.md` e `docs/SPEC.md`.

--- a/docs/specs/done/15-limitacoes-web-explicitas.md
+++ b/docs/specs/done/15-limitacoes-web-explicitas.md
@@ -1,7 +1,7 @@
 # Mini-spec: Limitações web explicitamente documentadas
 
 Número: 15
-Status: planejado
+Status: implementado
 
 ## Problema
 
@@ -37,18 +37,18 @@ Determinar, consolidar e documentar explicitamente as limitações conhecidas da
 - Registrar apenas limitações confirmadas pelo comportamento atual do app ou pela infraestrutura usada no projeto.
 - Diferenciar limitação estrutural da web de limitação atual de implementação.
 - Evitar linguagem ambígua como "pode funcionar" quando o comportamento esperado já for conhecido.
-- Manter coerência entre README, `docs/WEB_DEPLOY.md` e mini-spec ativa da web quando o mesmo tema aparecer em mais de um documento.
+- Manter coerência entre README, `docs/WEB_DEPLOY.md` e mini-spec da web quando o mesmo tema aparecer em mais de um documento.
 - Preservar textos em pt-BR e alinhados ao foco Android-first do projeto.
 
 ## Critérios de aceite
 
-- [ ] Existe uma lista explícita de limitações web em local de fácil acesso para usuários do projeto.
-- [ ] A documentação informa que compartilhamento via WhatsApp na web usa `wa.me`/WhatsApp Web, não deep link nativo.
-- [ ] A documentação informa que clipboard na web depende da Clipboard API do navegador e de contexto compatível (`https` ou `localhost`).
-- [ ] A documentação informa que persistência web é local ao navegador e separada do Android.
-- [ ] A documentação informa que a versão web ainda não possui suporte offline completo/PWA e depende de carregamento inicial com internet.
-- [ ] A documentação informa limitações conhecidas do fallback de roteamento SPA quando isso impactar comportamento observado ou troubleshooting.
-- [ ] Não há contradição entre README e `docs/WEB_DEPLOY.md` sobre capacidades e limites da plataforma web.
+- [x] Existe uma lista explícita de limitações web em local de fácil acesso para usuários do projeto.
+- [x] A documentação informa que compartilhamento via WhatsApp na web usa `wa.me`/WhatsApp Web, não deep link nativo.
+- [x] A documentação informa que clipboard na web depende da Clipboard API do navegador e de contexto compatível (`https` ou `localhost`).
+- [x] A documentação informa que persistência web é local ao navegador e separada do Android.
+- [x] A documentação informa que a versão web ainda não possui suporte offline completo/PWA e depende de carregamento inicial com internet.
+- [x] A documentação informa limitações conhecidas do fallback de roteamento SPA quando isso impactar comportamento observado ou troubleshooting.
+- [x] Não há contradição entre README e `docs/WEB_DEPLOY.md` sobre capacidades e limites da plataforma web.
 
 ## Fora de escopo
 
@@ -58,18 +58,23 @@ Determinar, consolidar e documentar explicitamente as limitações conhecidas da
 - Alterar o comportamento atual de compartilhamento, clipboard ou persistência.
 - Criar suíte E2E para validar a documentação.
 
-## Limitações candidatas a documentar
+## Limitações documentadas
 
 - Compartilhamento via WhatsApp na web ocorre por URL `wa.me`/WhatsApp Web, sem a mesma experiência de deep link nativo do Android.
 - Clipboard na web depende de permissão do navegador, HTTPS ou `localhost`, podendo falhar por bloqueio do ambiente.
 - Persistência fica restrita ao navegador/dispositivo atual e pode ser perdida ao limpar dados locais.
 - Web e Android não compartilham armazenamento nem sincronizam listas.
 - A build web não oferece suporte PWA/offline completo no estado atual.
-- O fallback de rotas profundas no GitHub Pages depende de `404.html` + `sessionStorage`, portanto comportamentos como hash, refresh extremo ou storage desabilitado devem ser tratados como limitação conhecida se confirmados.
+- O fallback de rotas profundas no GitHub Pages depende de `404.html` + `sessionStorage`; com storage desabilitado, o retorno da rota pode falhar.
 - Recursos nativos fora do escopo web, como notificações push e integrações específicas do dispositivo, não devem ser anunciados como disponíveis na web.
 
 ## Observações para IA
 
-- Antes de implementar esta mini-spec, revisar `README.md`, `docs/WEB_DEPLOY.md` e `docs/specs/active/08-web-github-pages.md` para eliminar divergências.
+- Antes de alterar limitações web, revisar `README.md`, `docs/WEB_DEPLOY.md` e mini-spec da web para evitar divergências.
 - Se alguma limitação ainda estiver incerta, confirmar o comportamento no app ou no código antes de documentar como fato.
 - Priorizar documentação útil para suporte e expectativa de uso, não apenas notas internas de implementação.
+
+## Registro de implementação
+
+- 2026-06-13: seção de limitações web consolidada no `README.md`.
+- 2026-06-13: seção de limitações conhecidas de deploy/documentação web ampliada em `docs/WEB_DEPLOY.md`.


### PR DESCRIPTION
## Resumo
Atualiza documentação e mini-specs para refletir o estado real da compatibilidade web com GitHub Pages após os commits recentes.

## O que foi alterado
- Atualiza `README.md` com status web como disponível e seção explícita de limitações conhecidas.
- Atualiza `docs/WEB_DEPLOY.md` com limitações adicionais (WhatsApp web, clipboard, persistência local e fallback SPA com `sessionStorage`).
- Alinha `docs/SPEC.md` para tratar web como plataforma suportada (com foco Android).
- Atualiza índice em `docs/specs/README.md`.
- Move mini-spec 08 de `active` para `done` com `Status: implementado`.
- Move mini-spec 15 de `planned` para `done` com critérios marcados e registro de implementação.

## Motivação
Garantir consistência entre commits recentes, documentação principal e organização das mini-specs por estágio.

## Validação
- Verificação de problemas/lint markdown nos arquivos alterados sem erros.
