### PR TITLE
fix: refatora finalização do new-version e restauração de WIP

### DIFF
--- a/scripts/add-new-version.sh
+++ b/scripts/add-new-version.sh
@@ -26,13 +26,4 @@ trap 'rc=$?; if [ "$rc" -ne 0 ] && [ "${WIP_STASH_CREATED:-0}" = "1" ] && [ "${W
 . ./scripts/lib/09-add-log.sh
 . ./scripts/lib/10-normalize-changelog.sh
 . ./scripts/lib/11-clear-files.sh
-
-if [ "$COMMIT_ARG" != 'n' ]; then
-  . ./scripts/lib/12-commit-changes.sh
-
-  echo "✔ Versão atualizada para $new_version"
-  echo "$TAB1➡ Publicando commit na branch atual..."
-  git push
-else
-  echo "✔ Versão atualizada para $new_version (sem commit)"
-fi
+. ./scripts/lib/13-final.sh

--- a/scripts/lib/12-commit-changes.sh
+++ b/scripts/lib/12-commit-changes.sh
@@ -14,15 +14,3 @@ fi
 git commit -m "chore: versão $new_version – $changes"
 echo "${TAB2}✔ Mudanças comitadas."
 echo ""
-
-if [ "${WIP_STASH_CREATED:-0}" = "1" ]; then
-  echo "${TAB1}🔍 Restaurando alterações WIP do stash..."
-  if git stash pop; then
-    WIP_POPPED=1
-    echo "${TAB2}✔ Alterações WIP restauradas com sucesso."
-  else
-    WIP_POPPED=1
-    echo "${TAB2}⚠ Falha ao aplicar stash automaticamente. Verifique conflitos e execute 'git stash list'/'git stash pop' manualmente."
-  fi
-fi
-echo ""

--- a/scripts/lib/13-final.sh
+++ b/scripts/lib/13-final.sh
@@ -1,0 +1,23 @@
+# Finalizando commitando ou não
+
+if [ "$COMMIT_ARG" != 'n' ]; then
+  . ./scripts/lib/12-commit-changes.sh
+
+  echo "✔ Versão atualizada para $new_version"
+  echo "$TAB1➡ Publicando commit na branch atual..."
+  git push
+else
+  echo "✔ Versão atualizada para $new_version (sem commit)"
+fi
+
+if [ "${WIP_STASH_CREATED:-0}" = "1" ]; then
+  echo "${TAB1}🔍 Restaurando alterações WIP do stash..."
+  if git stash pop; then
+    WIP_POPPED=1
+    echo "${TAB2}✔ Alterações WIP restauradas com sucesso."
+  else
+    WIP_POPPED=1
+    echo "${TAB2}⚠ Falha ao aplicar stash automaticamente. Verifique conflitos e execute 'git stash list'/'git stash pop' manualmente."
+  fi
+fi
+echo ""


### PR DESCRIPTION
## Resumo
- extrai a etapa final do fluxo de versionamento para módulo dedicado
- simplifica o script de commit para focar apenas em add/commit
- preserva e restaura alterações WIP no encerramento do fluxo

## Alterações
- `scripts/add-new-version.sh`: remove lógica inline de commit/push e delega para `scripts/lib/13-final.sh`
- `scripts/lib/12-commit-changes.sh`: mantém responsabilidade única de comitar mudanças
- `scripts/lib/13-final.sh` (novo): centraliza decisão de commit, push e restauração de stash WIP

## Motivação
- reduzir acoplamento no script principal
- melhorar legibilidade e manutenção do pipeline de versionamento
- tornar o comportamento final mais previsível
