### PR TITLE
fix: melhorar legibilidade dos botões de lembrete e versionar 1.7.1

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -2,7 +2,7 @@ export default {
   expo: {
     name: "Gastômetro",
     slug: "gastometro",
-    version: "1.7.0",
+    version: "1.7.1",
     orientation: "portrait",
     icon: "./assets/images/icon.png",
     scheme: "gastometro",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ Ajustes visuais nos botões do formulário de lembretes para melhorar legibilida
 
 ### Funcionalidade
 
-- Aumentado o tamanho do texto nos botões de ação do formulário de lembretes (`Salvar/Editar` e `Remover`) para melhorar a leitura.
+- Reduzindo o tamanho do texto nos botões de ação do formulário de lembretes (`Salvar/Editar` e `Remover`) para melhorar a leitura.
 - Simplificados os rótulos dos botões de edição e remoção de lembretes de `Editar Lembrete`/`Remover Lembrete` para `Editar`/`Remover`.
 
 ### Impacto

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.7.1 - 2026-06-23
+
+Ajustes visuais nos botões do formulário de lembretes para melhorar legibilidade e simplificação dos rótulos de ação.
+
+### Funcionalidade
+
+- Aumentado o tamanho do texto nos botões de ação do formulário de lembretes (`Salvar/Editar` e `Remover`) para melhorar a leitura.
+- Simplificados os rótulos dos botões de edição e remoção de lembretes de `Editar Lembrete`/`Remover Lembrete` para `Editar`/`Remover`.
+
+### Impacto
+
+- Mudança focada em UX/visual; sem alteração de formato de dados persistidos e sem impacto no compartilhamento via WhatsApp.
+
 ## 1.7.0 - 2026-06-21
 
 Implementação completa da mini-spec 10 com sistema de lembretes locais e notificações, incluindo CRUD por lista, central consolidada, fallback sem permissão e sincronização no bootstrap do app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gastometro",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gastometro",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~56.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gastometro",
   "main": "expo-router/entry",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "homepage": "https://stephhoel.github.io/gastometro/",
   "scripts": {
     "verify:version-bump": "sh ./scripts/verify-version-bump.sh",

--- a/src/components/Form/Reminder.tsx
+++ b/src/components/Form/Reminder.tsx
@@ -106,13 +106,13 @@ export function FormReminder({ listId, reminderId, textButton, iconButton, inclu
             <Button.Icon>
               <TrashIcon color={COLORS.black} size={SIZE.iconButton} />
             </Button.Icon>
-            <Button.Text>{REMINDERS.button.remove}</Button.Text>
+            <Button.Text className='text-2xl'>{REMINDERS.button.remove}</Button.Text>
           </Button>
         )}
 
         <Button onPress={handleSaveReminder} className='flex-1'>
           <Button.Icon>{iconButton}</Button.Icon>
-          <Button.Text>{textButton}</Button.Text>
+          <Button.Text className='text-2xl'>{textButton}</Button.Text>
         </Button>
       </Row>
     </View>

--- a/src/constants/text/reminders.ts
+++ b/src/constants/text/reminders.ts
@@ -10,8 +10,8 @@ export const REMINDERS = {
   },
   button: {
     create: 'Novo Lembrete',
-    update: 'Editar Lembrete',
-    remove: 'Remover Lembrete',
+    update: 'Editar',
+    remove: 'Remover',
   },
   empty_list: 'Nenhum lembrete para esta lista.',
   enable_button: 'Ativar',


### PR DESCRIPTION
# Pull Request

## Tipo de alteração

<!-- Marque apenas o tipo principal -->

- [ ] `feat` — nova funcionalidade
- [x] `fix` — correção de bug
- [ ] `chore` — versão, dependências ou automação
- [ ] `refactor` — refatoração sem mudança de comportamento
- [ ] `docs` — documentação
- [ ] `test` — adição ou ajuste de testes

## Descrição

Ajusta a UI do formulário de lembretes para melhorar legibilidade nos botões de ação e simplifica os rótulos de edição/remoção. Também aplica o bump de versão para `1.7.1` e registra a entrada correspondente no changelog.

## Mini-spec relacionada

não se aplica

## Arquivos alterados

- `src/components/Form/Reminder.tsx` — aumenta o tamanho do texto dos botões de ação do formulário.
- `src/constants/text/reminders.ts` — simplifica os rótulos de `Editar Lembrete`/`Remover Lembrete` para `Editar`/`Remover`.
- `package.json` — atualiza versão para `1.7.1`.
- `app.config.js` — sincroniza versão para `1.7.1`.
- `package-lock.json` — atualizado pelo `npm i` durante o fluxo de versionamento.
- `docs/CHANGELOG.md` — adiciona entrada da versão `1.7.1`.

## Verificações executadas

- [x] `npm run test` passou (cobertura ≥ 80%)
- [x] `npm run check:ts` passou (TypeScript sem erros de tipo)
- [x] Sem uso de `any`
- [x] Biome (`npm run check:biome`) sem erros bloqueantes — quando aplicável

## Checklist de qualidade

- [ ] Testes criados ou atualizados proporcionalmente ao escopo
- [x] Todo hook com tratamento de erro
- [x] Imports internos usando alias `@/`
- [x] Textos do usuário em pt-BR preservados
- [x] Regras de moeda/números BRL e vírgula/ponto preservadas
- [x] Formato de persistência (`gastometro` no AsyncStorage) não alterado sem plano de migração
- [x] Formato de compartilhamento WhatsApp preservado (retrocompatibilidade)
- [x] Documentação atualizada (`docs/CHANGELOG.md`, `docs/SPEC.md`, `README.md` se aplicável)

## Versionamento

<!-- Marque se este PR altera src/ e/ou tests/ -->

- [x] `package.json` e `app.config.js` atualizados com nova versão
- [ ] `android/app/build.gradle` atualizado (`versionName`) — se existir e aplicável
- [x] Entrada adicionada no topo de `docs/CHANGELOG.md`
- [ ] Não se aplica (PR não altera código ou testes)

## Riscos e pendências

- Risco baixo: alteração concentrada em texto/estilo de botões do formulário de lembretes.
- Sem breaking changes.
- Sem mudança de formato de dados persistidos.
- Sem impacto no formato de compartilhamento via WhatsApp.
